### PR TITLE
fixed: Dictionary should have pointer to pointer

### DIFF
--- a/avcodec/avcodec.go
+++ b/avcodec/avcodec.go
@@ -652,7 +652,7 @@ func (ctx *Context) OpenWithCodec(codec *Codec, options *avutil.Dictionary) erro
 	}
 	var cOptions **C.AVDictionary
 	if options != nil {
-		cOptions = (**C.AVDictionary)(unsafe.Pointer(&options.CAVDictionary))
+		cOptions = (**C.AVDictionary)(options.Pointer())
 	}
 	code := C.avcodec_open2(ctx.CAVCodecContext, cCodec, cOptions)
 	if code < 0 {

--- a/avfilter/avfilter.go
+++ b/avfilter/avfilter.go
@@ -333,7 +333,7 @@ func (ctx *Context) InitWithString(args string) error {
 func (ctx *Context) InitWithDictionary(options *avutil.Dictionary) error {
 	var cOptions **C.AVDictionary
 	if options != nil {
-		cOptions = (**C.AVDictionary)(unsafe.Pointer(&options.CAVDictionary))
+		cOptions = (**C.AVDictionary)(options.Pointer())
 	}
 	code := C.avfilter_init_dict(ctx.CAVFilterContext, cOptions)
 	if code < 0 {

--- a/avformat/avformat.go
+++ b/avformat/avformat.go
@@ -478,16 +478,13 @@ func (s *Stream) SetDisposition(disposition Disposition) {
 }
 
 func (s *Stream) MetaData() *avutil.Dictionary {
-	if s.CAVStream.metadata == nil {
-		return nil
-	}
-	return avutil.NewDictionaryFromC(unsafe.Pointer(s.CAVStream.metadata))
+	return avutil.NewDictionaryFromC(unsafe.Pointer(&s.CAVStream.metadata))
 }
 
 func (s *Stream) SetMetaData(metaData *avutil.Dictionary) {
 	var cMetaData *C.AVDictionary
 	if metaData != nil {
-		cMetaData = (*C.AVDictionary)(unsafe.Pointer(metaData.CAVDictionary))
+		cMetaData = (*C.AVDictionary)(metaData.Value())
 	}
 	s.CAVStream.metadata = cMetaData
 }
@@ -610,7 +607,7 @@ func (ctx *Context) NumberOfStreams() uint {
 func (ctx *Context) WriteHeader(options *avutil.Dictionary) error {
 	var cOptions **C.AVDictionary
 	if options != nil {
-		cOptions = (**C.AVDictionary)(unsafe.Pointer(&options.CAVDictionary))
+		cOptions = (**C.AVDictionary)(options.Pointer())
 	}
 	code := C.avformat_write_header(ctx.CAVFormatContext, cOptions)
 	if code < 0 {
@@ -736,16 +733,13 @@ func (ctx *Context) SubtitleCodecID() avcodec.CodecID {
 }
 
 func (ctx *Context) MetaData() *avutil.Dictionary {
-	if ctx.CAVFormatContext.metadata == nil {
-		return nil
-	}
-	return avutil.NewDictionaryFromC(unsafe.Pointer(ctx.CAVFormatContext.metadata))
+	return avutil.NewDictionaryFromC(unsafe.Pointer(&ctx.CAVFormatContext.metadata))
 }
 
 func (ctx *Context) SetMetaData(metaData *avutil.Dictionary) {
 	var cMetaData *C.AVDictionary
 	if metaData != nil {
-		cMetaData = (*C.AVDictionary)(unsafe.Pointer(metaData.CAVDictionary))
+		cMetaData = (*C.AVDictionary)(metaData.Value())
 	}
 	ctx.CAVFormatContext.metadata = cMetaData
 }
@@ -763,7 +757,7 @@ func (ctx *Context) OpenInput(fileName string, input *Input, options *avutil.Dic
 	}
 	var cOptions **C.AVDictionary
 	if options != nil {
-		cOptions = (**C.AVDictionary)(unsafe.Pointer(&options.CAVDictionary))
+		cOptions = (**C.AVDictionary)(options.Pointer())
 	}
 	code := C.avformat_open_input(&ctx.CAVFormatContext, cFileName, cInput, cOptions)
 	if code < 0 {
@@ -834,7 +828,7 @@ func OpenIOContext(url string, flags IOFlags, cb *IOInterruptCallback, options *
 	}
 	var cOptions **C.AVDictionary
 	if options != nil {
-		cOptions = (**C.AVDictionary)(unsafe.Pointer(&options.CAVDictionary))
+		cOptions = (**C.AVDictionary)(options.Pointer())
 	}
 	var cCtx *C.AVIOContext
 	code := C.avio_open2(&cCtx, cURL, (C.int)(flags), cCb, cOptions)
@@ -896,7 +890,7 @@ func newCAVDictionaryArrayFromDictionarySlice(dicts []*avutil.Dictionary) **C.AV
 		if dicts[i] == nil {
 			dicts[i] = avutil.NewDictionary()
 		}
-		C.go_av_dicts_set(arr, C.int(i), (*C.AVDictionary)(dicts[i].CAVDictionary))
+		C.go_av_dicts_set(arr, C.int(i), (*C.AVDictionary)(dicts[i].Value()))
 	}
 	return nil
 }

--- a/avformat/avformat_test.go
+++ b/avformat/avformat_test.go
@@ -378,3 +378,64 @@ func TestContextMaxDelay(t *testing.T) {
 		t.Fatalf("[TestContextMaxDelay] result = %d, NG, expected = %d", result, 500000)
 	}
 }
+
+func TestContextMetaData(t *testing.T) {
+	fmtCtx, err := NewContextForInput()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer fmtCtx.Free()
+	metadata := fmtCtx.MetaData()
+	if count := metadata.Count(); count != 0 {
+		t.Fatalf("Expecting count but got %d", count)
+	}
+	if err := metadata.Set("foo", "foo"); err != nil {
+		t.Fatal(err)
+	}
+	if count := metadata.Count(); count != 1 {
+		t.Fatalf("Expecting count but got %d", count)
+	}
+	if count := fmtCtx.MetaData().Count(); count != 1 {
+		t.Fatalf("Expecting count but got %d", count)
+	}
+	if err := metadata.Delete("foo"); err != nil {
+		t.Fatal(err)
+	}
+	if count := metadata.Count(); count != 0 {
+		t.Fatalf("Expecting count but got %d", count)
+	}
+	if err := metadata.Set("bar", "bar"); err != nil {
+		t.Fatal(err)
+	}
+	if count := metadata.Count(); count != 1 {
+		t.Fatalf("Expecting count but got %d", count)
+	}
+	if count := fmtCtx.MetaData().Count(); count != 1 {
+		t.Fatalf("Expecting count but got %d", count)
+	}
+	if err := metadata.Delete("bar"); err != nil {
+		t.Fatal(err)
+	}
+	if count := metadata.Count(); count != 0 {
+		t.Fatalf("Expecting count but got %d", count)
+	}
+}
+
+func TestContextSetMetaData(t *testing.T) {
+	fmtCtx, err := NewContextForInput()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer fmtCtx.Free()
+	if count := fmtCtx.MetaData().Count(); count != 0 {
+		t.Fatalf("Expecting count but got %d", count)
+	}
+	metadata := avutil.NewDictionary()
+	if err := metadata.Set("foo", "foo"); err != nil {
+		t.Fatal(err)
+	}
+	fmtCtx.SetMetaData(metadata)
+	if count := fmtCtx.MetaData().Count(); count != 1 {
+		t.Fatalf("Expecting count but got %d", count)
+	}
+}

--- a/avutil/avutil_test.go
+++ b/avutil/avutil_test.go
@@ -295,13 +295,22 @@ func TestDictionaryFreeCountFreeCount(t *testing.T) {
 func TestDictionaryFreeSetGetFreeGet(t *testing.T) {
 	dict := NewDictionary()
 	dict.Free()
+	if dict.CAVDictionary != nil || dict.pCAVDictionary != nil {
+		t.Fatal("Invalid pointer")
+	}
 	if err := dict.Set("foo", "bar"); err != nil {
 		t.Fatal(err)
+	}
+	if dict.CAVDictionary != nil || dict.pCAVDictionary == nil {
+		t.Fatal("Invalid pointer")
 	}
 	if value, ok := dict.GetOk("foo"); !ok || value != "bar" {
 		t.Fatal("Expecting value")
 	}
 	dict.Free()
+	if dict.CAVDictionary != nil || dict.pCAVDictionary != nil {
+		t.Fatal("Invalid pointer")
+	}
 	if value, ok := dict.GetOk("foo"); ok || value != "" {
 		t.Fatal("Not expecting value")
 	}


### PR DESCRIPTION
Dictionaries built from cgo pointers should keep the reference to the original pointer.
For instance, ```avformat.Context``` has a `MetaData()` that returns a dictionary.
This fix makes it return always a non nil Dictionary that, when modified, will alter the metadata of the ```Context``` object.