### PR TITLE
remove "deprecated-declarations" warnings

### DIFF
--- a/avcodec/avcodec.go
+++ b/avcodec/avcodec.go
@@ -119,6 +119,7 @@ package avcodec
 // int GO_AVCODEC_VERSION_MINOR = LIBAVCODEC_VERSION_MINOR;
 // int GO_AVCODEC_VERSION_MICRO = LIBAVCODEC_VERSION_MICRO;
 //
+// #cgo CFLAGS: -Wno-deprecated-declarations
 // #cgo pkg-config: libavcodec libavutil
 import "C"
 

--- a/avfilter/avfilter.go
+++ b/avfilter/avfilter.go
@@ -30,6 +30,7 @@ package avfilter
 //#define GO_AVFILTER_AUTO_CONVERT_ALL ((unsigned)AVFILTER_AUTO_CONVERT_ALL)
 //#define GO_AVFILTER_AUTO_CONVERT_NONE ((unsigned)AVFILTER_AUTO_CONVERT_NONE)
 //
+// #cgo CFLAGS: -Wno-deprecated-declarations
 //#cgo pkg-config: libavfilter libavutil
 import "C"
 

--- a/avformat/avformat.go
+++ b/avformat/avformat.go
@@ -36,6 +36,7 @@ package avformat
 //typedef int (*AVFormatContextIOOpenCallback)(struct AVFormatContext *s, AVIOContext **pb, const char *url, int flags, AVDictionary **options);
 //typedef void (*AVFormatContextIOCloseCallback)(struct AVFormatContext *s, AVIOContext *pb);
 //
+// #cgo CFLAGS: -Wno-deprecated-declarations
 // #cgo pkg-config: libavformat libavutil
 import "C"
 

--- a/avutil/avutil.go
+++ b/avutil/avutil.go
@@ -54,6 +54,7 @@ package avutil
 //  return AVERROR(e);
 //}
 //
+// #cgo CFLAGS: -Wno-deprecated-declarations
 // #cgo pkg-config: libavutil
 import "C"
 


### PR DESCRIPTION
**Before**
```
$ go build examples/transcoder.go
# github.com/imkira/go-libav/avcodec
avcodec/avcodec.go: In function ‘_cgo_a038601aec5c_Cfunc_av_bitstream_filter_close’:
avcodec/avcodec.go:162:2: warning: ‘av_bitstream_filter_close’ is deprecated [-Wdeprecated-declarations]
  FlagLowDelay      Flags = C.CODEC_FLAG_LOW_DELAY
  ^~~~~~~~~~~~~~~~~~~~~~~~~
In file included from avcodec/avcodec.go:4:0:
/usr/include/ffmpeg/libavcodec/avcodec.h:5836:6: note: declared here
 void av_bitstream_filter_close(AVBitStreamFilterContext *bsf);
      ^~~~~~~~~~~~~~~~~~~~~~~~~

...
```

**After**
```
$ go build examples/transcoder.go
$
```