### PR TITLE
Updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,7 @@
 - Increment version to compile against 4.3
 - Add `avcodec.Packet.Write`, `avcodec.Packet.WriteBytes`, `avcodec.Packet.GetDataAt` methods
 - Add `avcodec.IOContext.Error` method
+- Add `avcodec.IOContext.Flush` method
+- Use go builtin to get go byte array from C
+- Add `avcodec.Packet.GetDataInto` to get data into an existing go byte array
+- Make `avcodec.Packet.Free` a noop on a nil packet (aligns with libav convention)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,6 @@
 - Add ability to unset the 'interrupt' flag for a fmt context so you can stop it returning AVERROR_EXIT
 - Change avfilter.Context.SendCommand to return (string, error) so we can read the return data. User now sets the expected length and go allocates a buffer
 - Adds a packet.Copy method
+- Increment version to compile against 4.3
+- Add `avcodec.Packet.Write`, `avcodec.Packet.WriteBytes`, `avcodec.Packet.GetDataAt` methods
+- Add `avcodec.IOContext.Error` method

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,4 @@
 # [ Unreleased ]
 
 - Change avformat.Context.ControlMessage to return (int64, error) so we can return data from the control message
+- Expose the AV_NO_PTS_VALUE in avutil

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# CHANGELOG
+
+# [ Unreleased ]
+
+- Change avformat.Context.ControlMessage to return (int64, error) so we can return data from the control message

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@
 - Expose the AV_NO_PTS_VALUE in avutil
 - Add ability to unset the 'interrupt' flag for a fmt context so you can stop it returning AVERROR_EXIT
 - Change avfilter.Context.SendCommand to return (string, error) so we can read the return data. User now sets the expected length and go allocates a buffer
+- Adds a packet.Copy method

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,4 @@
 - Change avformat.Context.ControlMessage to return (int64, error) so we can return data from the control message
 - Expose the AV_NO_PTS_VALUE in avutil
 - Add ability to unset the 'interrupt' flag for a fmt context so you can stop it returning AVERROR_EXIT
+- Change avfilter.Context.SendCommand to return (string, error) so we can read the return data. User now sets the expected length and go allocates a buffer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,4 @@
 
 - Change avformat.Context.ControlMessage to return (int64, error) so we can return data from the control message
 - Expose the AV_NO_PTS_VALUE in avutil
+- Add ability to unset the 'interrupt' flag for a fmt context so you can stop it returning AVERROR_EXIT

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ FIXTURE_TARGETS=$(addprefix fixtures/,$(FIXTURES))
 $(FIXTURE_TARGETS):
 	mkdir -p "$(dir $@)"
 	rm -f "$@.zip" "$@"
-	cd "$(dir $@)" && curl -L "https://bintray.com/imkira/go-libav/download_file?file_path=$(notdir $@)" -o "$(notdir $@)"
+	cd "$(dir $@)" && curl -L "https://bintray.com/SpalkLtd/go-libav/download_file?file_path=$(notdir $@)" -o "$(notdir $@)"
 	rm -f "$@.zip"
 
 fixtures: $(FIXTURE_TARGETS)

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # go-libav
 
-[![License](http://img.shields.io/badge/license-MIT-red.svg?style=flat)](https://github.com/imkira/go-libav/blob/master/LICENSE.txt)
-[![GoDoc](https://godoc.org/github.com/imkira/go-libav?status.svg)](https://godoc.org/github.com/imkira/go-libav)
+[![License](http://img.shields.io/badge/license-MIT-red.svg?style=flat)](https://github.com/SpalkLtd/go-libav/blob/master/LICENSE.txt)
+[![GoDoc](https://godoc.org/github.com/SpalkLtd/go-libav?status.svg)](https://godoc.org/github.com/SpalkLtd/go-libav)
 [![Build
-Status](http://img.shields.io/travis/imkira/go-libav.svg?style=flat)](https://travis-ci.org/imkira/go-libav)
-[![Coverage](http://img.shields.io/codecov/c/github/imkira/go-libav.svg?style=flat)](https://codecov.io/github/imkira/go-libav)
+Status](http://img.shields.io/travis/SpalkLtd/go-libav.svg?style=flat)](https://travis-ci.org/SpalkLtd/go-libav)
+[![Coverage](http://img.shields.io/codecov/c/github/SpalkLtd/go-libav.svg?style=flat)](https://codecov.io/github/SpalkLtd/go-libav)
 
 [Go](https://golang.org) language bindings for [ffmpeg](https://ffmpeg.org)
 libraries.
@@ -26,29 +26,29 @@ The reason I decided to build go-libav was because I wanted to have:
 First, install ffmpeg 3.x libraries on your system.
 
 If you need ffmpeg2.x support, use
-[ffmpeg2](https://github.com/imkira/go-libav/tree/ffmpeg2) branch (deprecated).
+[ffmpeg2](https://github.com/SpalkLtd/go-libav/tree/ffmpeg2) branch (deprecated).
 
 Then, open the terminal and install the following packages:
 
 ```
-go get -u github.com/imkira/go-libav/avcodec
-go get -u github.com/imkira/go-libav/avfilter
-go get -u github.com/imkira/go-libav/avformat
-go get -u github.com/imkira/go-libav/avutil
+go get -u github.com/SpalkLtd/go-libav/avcodec
+go get -u github.com/SpalkLtd/go-libav/avfilter
+go get -u github.com/SpalkLtd/go-libav/avformat
+go get -u github.com/SpalkLtd/go-libav/avutil
 ```
 
 # Documentation
 
 For advanced usage, make sure to check the following documentation:
 
-- [avcodec](http://godoc.org/github.com/imkira/go-libav/avcodec)
-- [avfilter](http://godoc.org/github.com/imkira/go-libav/avfilter)
-- [avformat](http://godoc.org/github.com/imkira/go-libav/avformat)
-- [avutil](http://godoc.org/github.com/imkira/go-libav/avutil)
+- [avcodec](http://godoc.org/github.com/SpalkLtd/go-libav/avcodec)
+- [avfilter](http://godoc.org/github.com/SpalkLtd/go-libav/avfilter)
+- [avformat](http://godoc.org/github.com/SpalkLtd/go-libav/avformat)
+- [avutil](http://godoc.org/github.com/SpalkLtd/go-libav/avutil)
 
 # Examples
 
-Please check [here for examples](https://github.com/imkira/go-libav/tree/master/examples).
+Please check [here for examples](https://github.com/SpalkLtd/go-libav/tree/master/examples).
 
 # FFmpeg versions
 
@@ -77,5 +77,5 @@ www.opensource.org/licenses/MIT
 # Copyright
 
 Copyright (c) 2015 Mario Freitas. See
-[LICENSE](http://github.com/imkira/go-libav/blob/master/LICENSE)
+[LICENSE](http://github.com/SpalkLtd/go-libav/blob/master/LICENSE)
 for further details.

--- a/avcodec/avcodec.go
+++ b/avcodec/avcodec.go
@@ -119,7 +119,7 @@ package avcodec
 // int GO_AVCODEC_VERSION_MINOR = LIBAVCODEC_VERSION_MINOR;
 // int GO_AVCODEC_VERSION_MICRO = LIBAVCODEC_VERSION_MICRO;
 //
-// #cgo pkg-config: libavcodec libavutil
+// #cgo LDFLAGS: -lavcodec -lavutil
 import "C"
 
 import (

--- a/avcodec/avcodec.go
+++ b/avcodec/avcodec.go
@@ -118,6 +118,9 @@ package avcodec
 //static uint8_t go_get_data_at(uint8_t *arr, int index) {
 //    return arr[index];
 //}
+//static void set_data_at(uint8_t *arr, int index, uint8_t data) {
+//	  arr[index] = data;
+//}
 //
 // int GO_AVCODEC_VERSION_MAJOR = LIBAVCODEC_VERSION_MAJOR;
 // int GO_AVCODEC_VERSION_MINOR = LIBAVCODEC_VERSION_MINOR;
@@ -448,6 +451,10 @@ func (pkt *Packet) GetData() []byte {
 		data[i] = byte(C.go_get_data_at((*C.uint8_t)(pkt.Data()), C.int(i)))
 	}
 	return data
+}
+
+func (pkt *Packet) GetDataAt(index int) byte {
+	return byte(C.go_get_data_at((*C.uint8_t)(pkt.Data()), C.int(index)))
 }
 
 func (pkt *Packet) SetData(data unsafe.Pointer) {

--- a/avcodec/avcodec.go
+++ b/avcodec/avcodec.go
@@ -154,61 +154,62 @@ const (
 
 type Flags int
 
-// const (
-// 	FlagUnaligned     Flags = C.CODEC_FLAG_UNALIGNED
-// 	FlagQScale        Flags = C.CODEC_FLAG_QSCALE
-// 	Flag4MV           Flags = C.CODEC_FLAG_4MV
-// 	FlagOutputCorrupt Flags = C.CODEC_FLAG_OUTPUT_CORRUPT
-// 	FlagQPEL          Flags = C.CODEC_FLAG_QPEL
-// 	FlagPass1         Flags = C.CODEC_FLAG_PASS1
-// 	FlagPass2         Flags = C.CODEC_FLAG_PASS2
-// 	FlagGray          Flags = C.CODEC_FLAG_GRAY
-// 	FlagPSNR          Flags = C.CODEC_FLAG_PSNR
-// 	FlagTruncated     Flags = C.CODEC_FLAG_TRUNCATED
-// 	FlagInterlacedDCT Flags = C.CODEC_FLAG_INTERLACED_DCT
-// 	FlagLowDelay      Flags = C.CODEC_FLAG_LOW_DELAY
-// 	FlagGlobalHeader  Flags = C.CODEC_FLAG_GLOBAL_HEADER
-// 	FlagBitExact      Flags = C.CODEC_FLAG_BITEXACT
-// 	FlagACPred        Flags = C.CODEC_FLAG_AC_PRED
-// 	FlagLoopFilter    Flags = C.CODEC_FLAG_LOOP_FILTER
-// 	FlagInterlacedME  Flags = C.CODEC_FLAG_INTERLACED_ME
-// 	FlagClosedGOP     Flags = C.CODEC_FLAG_CLOSED_GOP
-// )
+const (
+	FlagUnaligned Flags = C.AV_CODEC_FLAG_UNALIGNED
+
+	FlagQScale        Flags = C.AV_CODEC_FLAG_QSCALE
+	Flag4MV           Flags = C.AV_CODEC_FLAG_4MV
+	FlagOutputCorrupt Flags = C.AV_CODEC_FLAG_OUTPUT_CORRUPT
+	FlagQPEL          Flags = C.AV_CODEC_FLAG_QPEL
+	FlagPass1         Flags = C.AV_CODEC_FLAG_PASS1
+	FlagPass2         Flags = C.AV_CODEC_FLAG_PASS2
+	FlagGray          Flags = C.AV_CODEC_FLAG_GRAY
+	FlagPSNR          Flags = C.AV_CODEC_FLAG_PSNR
+	FlagTruncated     Flags = C.AV_CODEC_FLAG_TRUNCATED
+	FlagInterlacedDCT Flags = C.AV_CODEC_FLAG_INTERLACED_DCT
+	FlagLowDelay      Flags = C.AV_CODEC_FLAG_LOW_DELAY
+	FlagGlobalHeader  Flags = C.AV_CODEC_FLAG_GLOBAL_HEADER
+	FlagBitExact      Flags = C.AV_CODEC_FLAG_BITEXACT
+	FlagACPred        Flags = C.AV_CODEC_FLAG_AC_PRED
+	FlagLoopFilter    Flags = C.AV_CODEC_FLAG_LOOP_FILTER
+	FlagInterlacedME  Flags = C.AV_CODEC_FLAG_INTERLACED_ME
+	FlagClosedGOP     Flags = C.AV_CODEC_FLAG_CLOSED_GOP
+)
 
 type Flags2 int
 
-// const (
-// 	Flag2Fast              Flags2 = C.CODEC_FLAG2_FAST
-// 	Flag2NoOutput          Flags2 = C.CODEC_FLAG2_NO_OUTPUT
-// 	Flag2LocalHeader       Flags2 = C.CODEC_FLAG2_LOCAL_HEADER
-// 	Flag2DropFrameTimecode Flags2 = C.CODEC_FLAG2_DROP_FRAME_TIMECODE
-// 	Flag2IgnoreCrop        Flags2 = C.CODEC_FLAG2_IGNORE_CROP
-// 	Flag2Chunks            Flags2 = C.CODEC_FLAG2_CHUNKS
-// 	Flag2ShowAll           Flags2 = C.CODEC_FLAG2_SHOW_ALL
-// 	Flag2ExportMvs         Flags2 = C.CODEC_FLAG2_EXPORT_MVS
-// 	Flag2SkipManual        Flags2 = C.CODEC_FLAG2_SKIP_MANUAL
-// )
+const (
+	Flag2Fast              Flags2 = C.AV_CODEC_FLAG2_FAST
+	Flag2NoOutput          Flags2 = C.AV_CODEC_FLAG2_NO_OUTPUT
+	Flag2LocalHeader       Flags2 = C.AV_CODEC_FLAG2_LOCAL_HEADER
+	Flag2DropFrameTimecode Flags2 = C.AV_CODEC_FLAG2_DROP_FRAME_TIMECODE
+	Flag2IgnoreCrop        Flags2 = C.AV_CODEC_FLAG2_IGNORE_CROP
+	Flag2Chunks            Flags2 = C.AV_CODEC_FLAG2_CHUNKS
+	Flag2ShowAll           Flags2 = C.AV_CODEC_FLAG2_SHOW_ALL
+	Flag2ExportMvs         Flags2 = C.AV_CODEC_FLAG2_EXPORT_MVS
+	Flag2SkipManual        Flags2 = C.AV_CODEC_FLAG2_SKIP_MANUAL
+)
 
 type Capabilities int
 
 const (
-	// CapabilityDrawHorizBand     Capabilities = C.CODEC_CAP_DRAW_HORIZ_BAND
-	// CapabilityDR1               Capabilities = C.CODEC_CAP_DR1
-	// CapabilityTruncated         Capabilities = C.CODEC_CAP_TRUNCATED
-	CapabilityHWAccel Capabilities = C.GO_CODEC_CAP_HWACCEL
-	// CapabilityDelay             Capabilities = C.CODEC_CAP_DELAY
-	// CapabilitySmallLastFrame    Capabilities = C.CODEC_CAP_SMALL_LAST_FRAME
-	CapabilityHWAccelVDPAU Capabilities = C.GO_CODEC_CAP_HWACCEL_VDPAU
-	// CapabilitySubframes         Capabilities = C.CODEC_CAP_SUBFRAMES
-	// CapabilityExperimental      Capabilities = C.CODEC_CAP_EXPERIMENTAL
-	// CapabilityChannelConf       Capabilities = C.CODEC_CAP_CHANNEL_CONF
-	// CapabilityFrameThreads      Capabilities = C.CODEC_CAP_FRAME_THREADS
-	// CapabilitySliceThreads      Capabilities = C.CODEC_CAP_SLICE_THREADS
-	// CapabilityParamChange       Capabilities = C.CODEC_CAP_PARAM_CHANGE
-	// CapabilityAutoThreads       Capabilities = C.CODEC_CAP_AUTO_THREADS
-	// CapabilityVariableFrameSize Capabilities = C.CODEC_CAP_VARIABLE_FRAME_SIZE
-	// CapabilityIntraOnly         Capabilities = C.CODEC_CAP_INTRA_ONLY
-	// CapabilityLossless          Capabilities = C.CODEC_CAP_LOSSLESS
+	CapabilityDrawHorizBand     Capabilities = C.AV_CODEC_CAP_DRAW_HORIZ_BAND
+	CapabilityDR1               Capabilities = C.AV_CODEC_CAP_DR1
+	CapabilityTruncated         Capabilities = C.AV_CODEC_CAP_TRUNCATED
+	CapabilityHWAccel           Capabilities = C.GO_CODEC_CAP_HWACCEL
+	CapabilityDelay             Capabilities = C.AV_CODEC_CAP_DELAY
+	CapabilitySmallLastFrame    Capabilities = C.AV_CODEC_CAP_SMALL_LAST_FRAME
+	CapabilityHWAccelVDPAU      Capabilities = C.GO_CODEC_CAP_HWACCEL_VDPAU
+	CapabilitySubframes         Capabilities = C.AV_CODEC_CAP_SUBFRAMES
+	CapabilityExperimental      Capabilities = C.AV_CODEC_CAP_EXPERIMENTAL
+	CapabilityChannelConf       Capabilities = C.AV_CODEC_CAP_CHANNEL_CONF
+	CapabilityFrameThreads      Capabilities = C.AV_CODEC_CAP_FRAME_THREADS
+	CapabilitySliceThreads      Capabilities = C.AV_CODEC_CAP_SLICE_THREADS
+	CapabilityParamChange       Capabilities = C.AV_CODEC_CAP_PARAM_CHANGE
+	CapabilityAutoThreads       Capabilities = C.AV_CODEC_CAP_AUTO_THREADS
+	CapabilityVariableFrameSize Capabilities = C.AV_CODEC_CAP_VARIABLE_FRAME_SIZE
+	CapabilityIntraOnly         Capabilities = C.AV_CODEC_CAP_INTRA_ONLY
+	CapabilityLossless          Capabilities = C.AV_CODEC_CAP_LOSSLESS
 )
 
 type Compliance int

--- a/avcodec/avcodec.go
+++ b/avcodec/avcodec.go
@@ -107,9 +107,6 @@ package avcodec
 //static uint8_t go_get_data_at(uint8_t *arr, int index) {
 //    return arr[index];
 //}
-//static void set_data_at(uint8_t *arr, int index, uint8_t data) {
-//	  arr[index] = data;
-//}
 //
 // int GO_AVCODEC_VERSION_MAJOR = LIBAVCODEC_VERSION_MAJOR;
 // int GO_AVCODEC_VERSION_MINOR = LIBAVCODEC_VERSION_MINOR;
@@ -405,9 +402,9 @@ func (pkt *Packet) SetBytes(b []byte) error {
 			return avutil.NewErrorFromCode(avutil.ErrorCode(ret))
 		}
 	}
-	for i := 0; i < len(b); i++ {
-		C.set_data_at(pkt.CAVPacket.data, C.int(i), (C.uint8_t)(b[i]))
-	}
+	buf := C.CBytes(b)
+	C.memcpy(unsafe.Pointer(pkt.CAVPacket.data), buf, C.ulong(len(b)))
+	C.free(buf)
 	pkt.CAVPacket.size = size
 	return nil
 }

--- a/avcodec/avcodec.go
+++ b/avcodec/avcodec.go
@@ -127,7 +127,7 @@ import (
 	"strings"
 	"unsafe"
 
-	"github.com/imkira/go-libav/avutil"
+	"github.com/SpalkLtd/go-libav/avutil"
 )
 
 var (

--- a/avcodec/avcodec.go
+++ b/avcodec/avcodec.go
@@ -3,17 +3,6 @@ package avcodec
 //#include <libavutil/avutil.h>
 //#include <libavcodec/avcodec.h>
 //
-//#ifdef CODEC_CAP_HWACCEL
-//#define GO_CODEC_CAP_HWACCEL CODEC_CAP_HWACCEL
-//#else
-//#define GO_CODEC_CAP_HWACCEL 0
-//#endif
-//
-//#ifdef CODEC_CAP_HWACCEL_VDPAU
-//#define GO_CODEC_CAP_HWACCEL_VDPAU CODEC_CAP_HWACCEL_VDPAU
-//#else
-//#define GO_CODEC_CAP_HWACCEL_VDPAU 0
-//#endif
 //
 //#ifdef FF_DCT_INT
 //#define GO_FF_DCT_INT FF_DCT_INT

--- a/avcodec/avcodec.go
+++ b/avcodec/avcodec.go
@@ -152,66 +152,6 @@ const (
 	CodecIDLJpeg CodecID = C.AV_CODEC_ID_LJPEG
 )
 
-type Flags int
-
-const (
-	FlagUnaligned Flags = C.AV_CODEC_FLAG_UNALIGNED
-
-	FlagQScale        Flags = C.AV_CODEC_FLAG_QSCALE
-	Flag4MV           Flags = C.AV_CODEC_FLAG_4MV
-	FlagOutputCorrupt Flags = C.AV_CODEC_FLAG_OUTPUT_CORRUPT
-	FlagQPEL          Flags = C.AV_CODEC_FLAG_QPEL
-	FlagPass1         Flags = C.AV_CODEC_FLAG_PASS1
-	FlagPass2         Flags = C.AV_CODEC_FLAG_PASS2
-	FlagGray          Flags = C.AV_CODEC_FLAG_GRAY
-	FlagPSNR          Flags = C.AV_CODEC_FLAG_PSNR
-	FlagTruncated     Flags = C.AV_CODEC_FLAG_TRUNCATED
-	FlagInterlacedDCT Flags = C.AV_CODEC_FLAG_INTERLACED_DCT
-	FlagLowDelay      Flags = C.AV_CODEC_FLAG_LOW_DELAY
-	FlagGlobalHeader  Flags = C.AV_CODEC_FLAG_GLOBAL_HEADER
-	FlagBitExact      Flags = C.AV_CODEC_FLAG_BITEXACT
-	FlagACPred        Flags = C.AV_CODEC_FLAG_AC_PRED
-	FlagLoopFilter    Flags = C.AV_CODEC_FLAG_LOOP_FILTER
-	FlagInterlacedME  Flags = C.AV_CODEC_FLAG_INTERLACED_ME
-	FlagClosedGOP     Flags = C.AV_CODEC_FLAG_CLOSED_GOP
-)
-
-type Flags2 int
-
-const (
-	Flag2Fast              Flags2 = C.AV_CODEC_FLAG2_FAST
-	Flag2NoOutput          Flags2 = C.AV_CODEC_FLAG2_NO_OUTPUT
-	Flag2LocalHeader       Flags2 = C.AV_CODEC_FLAG2_LOCAL_HEADER
-	Flag2DropFrameTimecode Flags2 = C.AV_CODEC_FLAG2_DROP_FRAME_TIMECODE
-	Flag2IgnoreCrop        Flags2 = C.AV_CODEC_FLAG2_IGNORE_CROP
-	Flag2Chunks            Flags2 = C.AV_CODEC_FLAG2_CHUNKS
-	Flag2ShowAll           Flags2 = C.AV_CODEC_FLAG2_SHOW_ALL
-	Flag2ExportMvs         Flags2 = C.AV_CODEC_FLAG2_EXPORT_MVS
-	Flag2SkipManual        Flags2 = C.AV_CODEC_FLAG2_SKIP_MANUAL
-)
-
-type Capabilities int
-
-const (
-	CapabilityDrawHorizBand     Capabilities = C.AV_CODEC_CAP_DRAW_HORIZ_BAND
-	CapabilityDR1               Capabilities = C.AV_CODEC_CAP_DR1
-	CapabilityTruncated         Capabilities = C.AV_CODEC_CAP_TRUNCATED
-	CapabilityHWAccel           Capabilities = C.GO_CODEC_CAP_HWACCEL
-	CapabilityDelay             Capabilities = C.AV_CODEC_CAP_DELAY
-	CapabilitySmallLastFrame    Capabilities = C.AV_CODEC_CAP_SMALL_LAST_FRAME
-	CapabilityHWAccelVDPAU      Capabilities = C.GO_CODEC_CAP_HWACCEL_VDPAU
-	CapabilitySubframes         Capabilities = C.AV_CODEC_CAP_SUBFRAMES
-	CapabilityExperimental      Capabilities = C.AV_CODEC_CAP_EXPERIMENTAL
-	CapabilityChannelConf       Capabilities = C.AV_CODEC_CAP_CHANNEL_CONF
-	CapabilityFrameThreads      Capabilities = C.AV_CODEC_CAP_FRAME_THREADS
-	CapabilitySliceThreads      Capabilities = C.AV_CODEC_CAP_SLICE_THREADS
-	CapabilityParamChange       Capabilities = C.AV_CODEC_CAP_PARAM_CHANGE
-	CapabilityAutoThreads       Capabilities = C.AV_CODEC_CAP_AUTO_THREADS
-	CapabilityVariableFrameSize Capabilities = C.AV_CODEC_CAP_VARIABLE_FRAME_SIZE
-	CapabilityIntraOnly         Capabilities = C.AV_CODEC_CAP_INTRA_ONLY
-	CapabilityLossless          Capabilities = C.AV_CODEC_CAP_LOSSLESS
-)
-
 type Compliance int
 
 const (

--- a/avcodec/avcodec.go
+++ b/avcodec/avcodec.go
@@ -314,7 +314,6 @@ func Version() (int, int, int) {
 	return int(C.GO_AVCODEC_VERSION_MAJOR), int(C.GO_AVCODEC_VERSION_MINOR), int(C.GO_AVCODEC_VERSION_MICRO)
 }
 
-
 func RegisterAll() {
 	C.avcodec_register_all()
 }
@@ -361,6 +360,19 @@ func NewPacket() (*Packet, error) {
 		return nil, ErrAllocationError
 	}
 	return NewPacketFromC(unsafe.Pointer(cPkt)), nil
+}
+
+func (pkt *Packet) Copy() (*Packet, error) {
+	newpacket, err := NewPacket()
+	if err != nil {
+		return newpacket, err
+	}
+	C.av_init_packet(newpacket.CAVPacket)
+	code := C.av_packet_ref(newpacket.CAVPacket, pkt.CAVPacket)
+	if code < 0 {
+		return newpacket, avutil.NewErrorFromCode(avutil.ErrorCode(code))
+	}
+	return newpacket, nil
 }
 
 func NewPacketFromC(cPkt unsafe.Pointer) *Packet {

--- a/avcodec/avcodec.go
+++ b/avcodec/avcodec.go
@@ -151,61 +151,61 @@ const (
 
 type Flags int
 
-const (
-	FlagUnaligned     Flags = C.CODEC_FLAG_UNALIGNED
-	FlagQScale        Flags = C.CODEC_FLAG_QSCALE
-	Flag4MV           Flags = C.CODEC_FLAG_4MV
-	FlagOutputCorrupt Flags = C.CODEC_FLAG_OUTPUT_CORRUPT
-	FlagQPEL          Flags = C.CODEC_FLAG_QPEL
-	FlagPass1         Flags = C.CODEC_FLAG_PASS1
-	FlagPass2         Flags = C.CODEC_FLAG_PASS2
-	FlagGray          Flags = C.CODEC_FLAG_GRAY
-	FlagPSNR          Flags = C.CODEC_FLAG_PSNR
-	FlagTruncated     Flags = C.CODEC_FLAG_TRUNCATED
-	FlagInterlacedDCT Flags = C.CODEC_FLAG_INTERLACED_DCT
-	FlagLowDelay      Flags = C.CODEC_FLAG_LOW_DELAY
-	FlagGlobalHeader  Flags = C.CODEC_FLAG_GLOBAL_HEADER
-	FlagBitExact      Flags = C.CODEC_FLAG_BITEXACT
-	FlagACPred        Flags = C.CODEC_FLAG_AC_PRED
-	FlagLoopFilter    Flags = C.CODEC_FLAG_LOOP_FILTER
-	FlagInterlacedME  Flags = C.CODEC_FLAG_INTERLACED_ME
-	FlagClosedGOP     Flags = C.CODEC_FLAG_CLOSED_GOP
-)
+// const (
+// 	FlagUnaligned     Flags = C.CODEC_FLAG_UNALIGNED
+// 	FlagQScale        Flags = C.CODEC_FLAG_QSCALE
+// 	Flag4MV           Flags = C.CODEC_FLAG_4MV
+// 	FlagOutputCorrupt Flags = C.CODEC_FLAG_OUTPUT_CORRUPT
+// 	FlagQPEL          Flags = C.CODEC_FLAG_QPEL
+// 	FlagPass1         Flags = C.CODEC_FLAG_PASS1
+// 	FlagPass2         Flags = C.CODEC_FLAG_PASS2
+// 	FlagGray          Flags = C.CODEC_FLAG_GRAY
+// 	FlagPSNR          Flags = C.CODEC_FLAG_PSNR
+// 	FlagTruncated     Flags = C.CODEC_FLAG_TRUNCATED
+// 	FlagInterlacedDCT Flags = C.CODEC_FLAG_INTERLACED_DCT
+// 	FlagLowDelay      Flags = C.CODEC_FLAG_LOW_DELAY
+// 	FlagGlobalHeader  Flags = C.CODEC_FLAG_GLOBAL_HEADER
+// 	FlagBitExact      Flags = C.CODEC_FLAG_BITEXACT
+// 	FlagACPred        Flags = C.CODEC_FLAG_AC_PRED
+// 	FlagLoopFilter    Flags = C.CODEC_FLAG_LOOP_FILTER
+// 	FlagInterlacedME  Flags = C.CODEC_FLAG_INTERLACED_ME
+// 	FlagClosedGOP     Flags = C.CODEC_FLAG_CLOSED_GOP
+// )
 
 type Flags2 int
 
-const (
-	Flag2Fast              Flags2 = C.CODEC_FLAG2_FAST
-	Flag2NoOutput          Flags2 = C.CODEC_FLAG2_NO_OUTPUT
-	Flag2LocalHeader       Flags2 = C.CODEC_FLAG2_LOCAL_HEADER
-	Flag2DropFrameTimecode Flags2 = C.CODEC_FLAG2_DROP_FRAME_TIMECODE
-	Flag2IgnoreCrop        Flags2 = C.CODEC_FLAG2_IGNORE_CROP
-	Flag2Chunks            Flags2 = C.CODEC_FLAG2_CHUNKS
-	Flag2ShowAll           Flags2 = C.CODEC_FLAG2_SHOW_ALL
-	Flag2ExportMvs         Flags2 = C.CODEC_FLAG2_EXPORT_MVS
-	Flag2SkipManual        Flags2 = C.CODEC_FLAG2_SKIP_MANUAL
-)
+// const (
+// 	Flag2Fast              Flags2 = C.CODEC_FLAG2_FAST
+// 	Flag2NoOutput          Flags2 = C.CODEC_FLAG2_NO_OUTPUT
+// 	Flag2LocalHeader       Flags2 = C.CODEC_FLAG2_LOCAL_HEADER
+// 	Flag2DropFrameTimecode Flags2 = C.CODEC_FLAG2_DROP_FRAME_TIMECODE
+// 	Flag2IgnoreCrop        Flags2 = C.CODEC_FLAG2_IGNORE_CROP
+// 	Flag2Chunks            Flags2 = C.CODEC_FLAG2_CHUNKS
+// 	Flag2ShowAll           Flags2 = C.CODEC_FLAG2_SHOW_ALL
+// 	Flag2ExportMvs         Flags2 = C.CODEC_FLAG2_EXPORT_MVS
+// 	Flag2SkipManual        Flags2 = C.CODEC_FLAG2_SKIP_MANUAL
+// )
 
 type Capabilities int
 
 const (
-	CapabilityDrawHorizBand     Capabilities = C.CODEC_CAP_DRAW_HORIZ_BAND
-	CapabilityDR1               Capabilities = C.CODEC_CAP_DR1
-	CapabilityTruncated         Capabilities = C.CODEC_CAP_TRUNCATED
-	CapabilityHWAccel           Capabilities = C.GO_CODEC_CAP_HWACCEL
-	CapabilityDelay             Capabilities = C.CODEC_CAP_DELAY
-	CapabilitySmallLastFrame    Capabilities = C.CODEC_CAP_SMALL_LAST_FRAME
-	CapabilityHWAccelVDPAU      Capabilities = C.GO_CODEC_CAP_HWACCEL_VDPAU
-	CapabilitySubframes         Capabilities = C.CODEC_CAP_SUBFRAMES
-	CapabilityExperimental      Capabilities = C.CODEC_CAP_EXPERIMENTAL
-	CapabilityChannelConf       Capabilities = C.CODEC_CAP_CHANNEL_CONF
-	CapabilityFrameThreads      Capabilities = C.CODEC_CAP_FRAME_THREADS
-	CapabilitySliceThreads      Capabilities = C.CODEC_CAP_SLICE_THREADS
-	CapabilityParamChange       Capabilities = C.CODEC_CAP_PARAM_CHANGE
-	CapabilityAutoThreads       Capabilities = C.CODEC_CAP_AUTO_THREADS
-	CapabilityVariableFrameSize Capabilities = C.CODEC_CAP_VARIABLE_FRAME_SIZE
-	CapabilityIntraOnly         Capabilities = C.CODEC_CAP_INTRA_ONLY
-	CapabilityLossless          Capabilities = C.CODEC_CAP_LOSSLESS
+	// CapabilityDrawHorizBand     Capabilities = C.CODEC_CAP_DRAW_HORIZ_BAND
+	// CapabilityDR1               Capabilities = C.CODEC_CAP_DR1
+	// CapabilityTruncated         Capabilities = C.CODEC_CAP_TRUNCATED
+	CapabilityHWAccel Capabilities = C.GO_CODEC_CAP_HWACCEL
+	// CapabilityDelay             Capabilities = C.CODEC_CAP_DELAY
+	// CapabilitySmallLastFrame    Capabilities = C.CODEC_CAP_SMALL_LAST_FRAME
+	CapabilityHWAccelVDPAU Capabilities = C.GO_CODEC_CAP_HWACCEL_VDPAU
+	// CapabilitySubframes         Capabilities = C.CODEC_CAP_SUBFRAMES
+	// CapabilityExperimental      Capabilities = C.CODEC_CAP_EXPERIMENTAL
+	// CapabilityChannelConf       Capabilities = C.CODEC_CAP_CHANNEL_CONF
+	// CapabilityFrameThreads      Capabilities = C.CODEC_CAP_FRAME_THREADS
+	// CapabilitySliceThreads      Capabilities = C.CODEC_CAP_SLICE_THREADS
+	// CapabilityParamChange       Capabilities = C.CODEC_CAP_PARAM_CHANGE
+	// CapabilityAutoThreads       Capabilities = C.CODEC_CAP_AUTO_THREADS
+	// CapabilityVariableFrameSize Capabilities = C.CODEC_CAP_VARIABLE_FRAME_SIZE
+	// CapabilityIntraOnly         Capabilities = C.CODEC_CAP_INTRA_ONLY
+	// CapabilityLossless          Capabilities = C.CODEC_CAP_LOSSLESS
 )
 
 type Compliance int
@@ -452,6 +452,27 @@ func (pkt *Packet) GetData() []byte {
 
 func (pkt *Packet) SetData(data unsafe.Pointer) {
 	pkt.CAVPacket.data = (*C.uint8_t)(data)
+}
+
+func (pkt *Packet) SetBytes(b []byte) error {
+	size := C.int(len(b))
+	if pkt.CAVPacket.data == nil {
+		ret := C.av_new_packet(pkt.CAVPacket, C.int(len(b)))
+		if ret < 0 {
+			return avutil.NewErrorFromCode(avutil.ErrorCode(ret))
+		}
+	}
+	if pkt.CAVPacket.size < size {
+		ret := C.av_grow_packet(pkt.CAVPacket, size-pkt.CAVPacket.size)
+		if ret < 0 {
+			return avutil.NewErrorFromCode(avutil.ErrorCode(ret))
+		}
+	}
+	for i := 0; i < len(b); i++ {
+		C.set_data_at(pkt.CAVPacket.data, C.int(i), (C.uint8_t)(b[i]))
+	}
+	pkt.CAVPacket.size = size
+	return nil
 }
 
 func (pkt *Packet) Size() int {

--- a/avcodec/avcodec.go
+++ b/avcodec/avcodec.go
@@ -115,6 +115,10 @@ package avcodec
 //  return list[idx];
 //}
 //
+//static uint8_t go_get_data_at(uint8_t *arr, int index) {
+//    return arr[index];
+//}
+//
 // int GO_AVCODEC_VERSION_MAJOR = LIBAVCODEC_VERSION_MAJOR;
 // int GO_AVCODEC_VERSION_MINOR = LIBAVCODEC_VERSION_MINOR;
 // int GO_AVCODEC_VERSION_MICRO = LIBAVCODEC_VERSION_MICRO;
@@ -435,6 +439,15 @@ func (pkt *Packet) SetDuration(duration int64) {
 
 func (pkt *Packet) Data() unsafe.Pointer {
 	return unsafe.Pointer(pkt.CAVPacket.data)
+}
+
+func (pkt *Packet) GetData() []byte {
+	pktSize := pkt.Size()
+	data := make([]byte, pktSize)
+	for i := 0; i < pktSize; i++ {
+		data[i] = byte(C.go_get_data_at((*C.uint8_t)(pkt.Data()), C.int(i)))
+	}
+	return data
 }
 
 func (pkt *Packet) SetData(data unsafe.Pointer) {

--- a/avcodec/avcodec30.go
+++ b/avcodec/avcodec30.go
@@ -11,7 +11,7 @@ import "C"
 import (
 	"unsafe"
 
-	"github.com/imkira/go-libav/avutil"
+	"github.com/SpalkLtd/go-libav/avutil"
 )
 
 func (ctx *Context) CopyTo(dst *Context) error {

--- a/avcodec/avcodec30.go
+++ b/avcodec/avcodec30.go
@@ -5,7 +5,7 @@ package avcodec
 //#include <libavutil/avutil.h>
 //#include <libavcodec/avcodec.h>
 //
-// #cgo pkg-config: libavcodec libavutil
+// #cgo LDFLAGS: -lavcodec -lavutil
 import "C"
 
 import (

--- a/avcodec/avcodec30_test.go
+++ b/avcodec/avcodec30_test.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/imkira/go-libav/avutil"
+	"github.com/SpalkLtd/go-libav/avutil"
 )
 
 func TestNewBitStreamFilterContextFromName(t *testing.T) {

--- a/avcodec/avcodec33.go
+++ b/avcodec/avcodec33.go
@@ -11,7 +11,7 @@ import "C"
 import (
 	"unsafe"
 
-	"github.com/imkira/go-libav/avutil"
+	"github.com/SpalkLtd/go-libav/avutil"
 )
 
 type CodecParameters struct {

--- a/avcodec/avcodec33.go
+++ b/avcodec/avcodec33.go
@@ -5,7 +5,7 @@ package avcodec
 //#include <libavutil/avutil.h>
 //#include <libavcodec/avcodec.h>
 //
-// #cgo pkg-config: libavcodec libavutil
+// #cgo LDFLAGS: -lavcodec -lavutil
 import "C"
 
 import (

--- a/avcodec/avcodec33.go
+++ b/avcodec/avcodec33.go
@@ -21,7 +21,8 @@ import (
 )
 
 var (
-	ErrGotNoFrame = errors.New("avcodec: GotFrame == 0, this means we got no frame from the encoder")
+	ErrGotNoFrame  = errors.New("avcodec: GotFrame == 0, this means we got no frame from the encoder")
+	ErrGotNoPacket = errors.New("avcodec: GotPacket == 0, this means we got no packet from the encoder")
 )
 
 type CodecParameters struct {
@@ -92,7 +93,7 @@ func (ctx *Context) Decode(pkt *Packet) (bool, []*avutil.Frame, error) {
 }
 
 func (ctx *Context) Encode(pkt *Packet, frames []*avutil.Frame) (int, error) {
-	var cGotFrame C.int
+	var cGotPkt C.int
 	var cFrame *C.AVFrame
 	var code C.int
 	var frame *avutil.Frame
@@ -120,9 +121,9 @@ func (ctx *Context) Encode(pkt *Packet, frames []*avutil.Frame) (int, error) {
 	}
 	cPkt := (*C.AVPacket)(unsafe.Pointer(pkt.CAVPacket))
 
-	cGotFrame = C.avcodec_receive_packet(ctx.CAVCodecContext, cPkt)
-	if cGotFrame == (C.int)(0) {
-		return count, ErrGotNoFrame
+	cGotPkt = C.avcodec_receive_packet(ctx.CAVCodecContext, cPkt)
+	if cGotPkt == (C.int)(0) {
+		return count, ErrGotNoPacket
 	}
 	return count, nil
 }

--- a/avcodec/avcodec33.go
+++ b/avcodec/avcodec33.go
@@ -1,5 +1,3 @@
-// +build ffmpeg33
-
 package avcodec
 
 //#include <libavutil/avutil.h>

--- a/avcodec/avcodec33.go
+++ b/avcodec/avcodec33.go
@@ -62,9 +62,13 @@ func (ctx *Context) CopyTo(dst *Context) error {
 }
 
 func (ctx *Context) SendPacket(pkt *Packet) error {
-
-	cPkt := (*C.AVPacket)(unsafe.Pointer(pkt.CAVPacket))
-	code := C.avcodec_send_packet(ctx.CAVCodecContext, cPkt)
+	var code C.int
+	if pkt == nil {
+		code = C.avcodec_send_packet(ctx.CAVCodecContext, nil)
+	} else {
+		cPkt := (*C.AVPacket)(unsafe.Pointer(pkt.CAVPacket))
+		code = C.avcodec_send_packet(ctx.CAVCodecContext, cPkt)
+	}
 	if code < 0 {
 		err := avutil.NewErrorFromCode(avutil.ErrorCode(code))
 		return err
@@ -82,8 +86,13 @@ func (ctx *Context) ReceiveFrame(frame *avutil.Frame) error {
 }
 
 func (ctx *Context) SendFrame(frame *avutil.Frame) error {
-	cFrame := (*C.AVFrame)(unsafe.Pointer(frame.CAVFrame))
-	code := C.avcodec_send_frame(ctx.CAVCodecContext, cFrame)
+	var code C.int
+	if frame == nil {
+		code = C.avcodec_send_frame(ctx.CAVCodecContext, nil)
+	} else {
+		cFrame := (*C.AVFrame)(unsafe.Pointer(frame.CAVFrame))
+		code = C.avcodec_send_frame(ctx.CAVCodecContext, cFrame)
+	}
 	if code < 0 {
 		err := avutil.NewErrorFromCode(avutil.ErrorCode(code))
 		return err
@@ -99,4 +108,8 @@ func (ctx *Context) ReceivePacket(pkt *Packet) error {
 		return err
 	}
 	return nil
+}
+
+func (ctx *Context) FlushBuffers() {
+	C.avcodec_flush_buffers(ctx.CAVCodecContext)
 }

--- a/avcodec/avcodec43.go
+++ b/avcodec/avcodec43.go
@@ -2,12 +2,24 @@
 
 package avcodec
 
-import "C"
-
 //#include <libavutil/avutil.h>
 //#include <libavcodec/avcodec.h>
 //
+//#ifdef CODEC_CAP_HWACCEL
+//#define GO_CODEC_CAP_HWACCEL CODEC_CAP_HWACCEL
+//#else
+//#define GO_CODEC_CAP_HWACCEL 0
+//#endif
+//
+//#ifdef CODEC_CAP_HWACCEL_VDPAU
+//#define GO_CODEC_CAP_HWACCEL_VDPAU CODEC_CAP_HWACCEL_VDPAU
+//#else
+//#define GO_CODEC_CAP_HWACCEL_VDPAU 0
+//#endif
+//
 // #cgo LDFLAGS: -lavcodec -lavutil
+import "C"
+
 type Flags int
 
 const (

--- a/avcodec/avcodec43.go
+++ b/avcodec/avcodec43.go
@@ -1,0 +1,69 @@
+// +build ffmpeg43
+
+package avcodec
+
+import "C"
+
+//#include <libavutil/avutil.h>
+//#include <libavcodec/avcodec.h>
+//
+// #cgo LDFLAGS: -lavcodec -lavutil
+type Flags int
+
+const (
+	FlagUnaligned Flags = C.AV_CODEC_FLAG_UNALIGNED
+
+	FlagQScale        Flags = C.AV_CODEC_FLAG_QSCALE
+	Flag4MV           Flags = C.AV_CODEC_FLAG_4MV
+	FlagOutputCorrupt Flags = C.AV_CODEC_FLAG_OUTPUT_CORRUPT
+	FlagQPEL          Flags = C.AV_CODEC_FLAG_QPEL
+	FlagPass1         Flags = C.AV_CODEC_FLAG_PASS1
+	FlagPass2         Flags = C.AV_CODEC_FLAG_PASS2
+	FlagGray          Flags = C.AV_CODEC_FLAG_GRAY
+	FlagPSNR          Flags = C.AV_CODEC_FLAG_PSNR
+	FlagTruncated     Flags = C.AV_CODEC_FLAG_TRUNCATED
+	FlagInterlacedDCT Flags = C.AV_CODEC_FLAG_INTERLACED_DCT
+	FlagLowDelay      Flags = C.AV_CODEC_FLAG_LOW_DELAY
+	FlagGlobalHeader  Flags = C.AV_CODEC_FLAG_GLOBAL_HEADER
+	FlagBitExact      Flags = C.AV_CODEC_FLAG_BITEXACT
+	FlagACPred        Flags = C.AV_CODEC_FLAG_AC_PRED
+	FlagLoopFilter    Flags = C.AV_CODEC_FLAG_LOOP_FILTER
+	FlagInterlacedME  Flags = C.AV_CODEC_FLAG_INTERLACED_ME
+	FlagClosedGOP     Flags = C.AV_CODEC_FLAG_CLOSED_GOP
+)
+
+type Flags2 int
+
+const (
+	Flag2Fast              Flags2 = C.AV_CODEC_FLAG2_FAST
+	Flag2NoOutput          Flags2 = C.AV_CODEC_FLAG2_NO_OUTPUT
+	Flag2LocalHeader       Flags2 = C.AV_CODEC_FLAG2_LOCAL_HEADER
+	Flag2DropFrameTimecode Flags2 = C.AV_CODEC_FLAG2_DROP_FRAME_TIMECODE
+	Flag2IgnoreCrop        Flags2 = C.AV_CODEC_FLAG2_IGNORE_CROP
+	Flag2Chunks            Flags2 = C.AV_CODEC_FLAG2_CHUNKS
+	Flag2ShowAll           Flags2 = C.AV_CODEC_FLAG2_SHOW_ALL
+	Flag2ExportMvs         Flags2 = C.AV_CODEC_FLAG2_EXPORT_MVS
+	Flag2SkipManual        Flags2 = C.AV_CODEC_FLAG2_SKIP_MANUAL
+)
+
+type Capabilities int
+
+const (
+	CapabilityDrawHorizBand     Capabilities = C.AV_CODEC_CAP_DRAW_HORIZ_BAND
+	CapabilityDR1               Capabilities = C.AV_CODEC_CAP_DR1
+	CapabilityTruncated         Capabilities = C.AV_CODEC_CAP_TRUNCATED
+	CapabilityHWAccel           Capabilities = C.GO_CODEC_CAP_HWACCEL
+	CapabilityDelay             Capabilities = C.AV_CODEC_CAP_DELAY
+	CapabilitySmallLastFrame    Capabilities = C.AV_CODEC_CAP_SMALL_LAST_FRAME
+	CapabilityHWAccelVDPAU      Capabilities = C.GO_CODEC_CAP_HWACCEL_VDPAU
+	CapabilitySubframes         Capabilities = C.AV_CODEC_CAP_SUBFRAMES
+	CapabilityExperimental      Capabilities = C.AV_CODEC_CAP_EXPERIMENTAL
+	CapabilityChannelConf       Capabilities = C.AV_CODEC_CAP_CHANNEL_CONF
+	CapabilityFrameThreads      Capabilities = C.AV_CODEC_CAP_FRAME_THREADS
+	CapabilitySliceThreads      Capabilities = C.AV_CODEC_CAP_SLICE_THREADS
+	CapabilityParamChange       Capabilities = C.AV_CODEC_CAP_PARAM_CHANGE
+	CapabilityAutoThreads       Capabilities = C.AV_CODEC_CAP_AUTO_THREADS
+	CapabilityVariableFrameSize Capabilities = C.AV_CODEC_CAP_VARIABLE_FRAME_SIZE
+	CapabilityIntraOnly         Capabilities = C.AV_CODEC_CAP_INTRA_ONLY
+	CapabilityLossless          Capabilities = C.AV_CODEC_CAP_LOSSLESS
+)

--- a/avcodec/avcodec_test.go
+++ b/avcodec/avcodec_test.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/imkira/go-libav/avutil"
+	"github.com/SpalkLtd/go-libav/avutil"
 	"github.com/shirou/gopsutil/process"
 )
 

--- a/avcodec/flags.go
+++ b/avcodec/flags.go
@@ -1,0 +1,81 @@
+// +build !ffmpeg43
+
+package avcodec
+
+//#include <libavutil/avutil.h>
+//#include <libavcodec/avcodec.h>
+//
+//
+//#ifdef CODEC_CAP_HWACCEL
+//#define GO_CODEC_CAP_HWACCEL CODEC_CAP_HWACCEL
+//#else
+//#define GO_CODEC_CAP_HWACCEL 0
+//#endif
+//
+//#ifdef CODEC_CAP_HWACCEL_VDPAU
+//#define GO_CODEC_CAP_HWACCEL_VDPAU CODEC_CAP_HWACCEL_VDPAU
+//#else
+//#define GO_CODEC_CAP_HWACCEL_VDPAU 0
+//#endif
+//
+// #cgo LDFLAGS: -lavcodec -lavutil
+import "C"
+
+type Flags int
+
+const (
+	FlagUnaligned     Flags = C.CODEC_FLAG_UNALIGNED
+	FlagQScale        Flags = C.CODEC_FLAG_QSCALE
+	Flag4MV           Flags = C.CODEC_FLAG_4MV
+	FlagOutputCorrupt Flags = C.CODEC_FLAG_OUTPUT_CORRUPT
+	FlagQPEL          Flags = C.CODEC_FLAG_QPEL
+	FlagPass1         Flags = C.CODEC_FLAG_PASS1
+	FlagPass2         Flags = C.CODEC_FLAG_PASS2
+	FlagGray          Flags = C.CODEC_FLAG_GRAY
+	FlagPSNR          Flags = C.CODEC_FLAG_PSNR
+	FlagTruncated     Flags = C.CODEC_FLAG_TRUNCATED
+	FlagInterlacedDCT Flags = C.CODEC_FLAG_INTERLACED_DCT
+	FlagLowDelay      Flags = C.CODEC_FLAG_LOW_DELAY
+	FlagGlobalHeader  Flags = C.CODEC_FLAG_GLOBAL_HEADER
+	FlagBitExact      Flags = C.CODEC_FLAG_BITEXACT
+	FlagACPred        Flags = C.CODEC_FLAG_AC_PRED
+	FlagLoopFilter    Flags = C.CODEC_FLAG_LOOP_FILTER
+	FlagInterlacedME  Flags = C.CODEC_FLAG_INTERLACED_ME
+	FlagClosedGOP     Flags = C.CODEC_FLAG_CLOSED_GOP
+)
+
+type Flags2 int
+
+const (
+	Flag2Fast              Flags2 = C.CODEC_FLAG2_FAST
+	Flag2NoOutput          Flags2 = C.CODEC_FLAG2_NO_OUTPUT
+	Flag2LocalHeader       Flags2 = C.CODEC_FLAG2_LOCAL_HEADER
+	Flag2DropFrameTimecode Flags2 = C.CODEC_FLAG2_DROP_FRAME_TIMECODE
+	Flag2IgnoreCrop        Flags2 = C.CODEC_FLAG2_IGNORE_CROP
+	Flag2Chunks            Flags2 = C.CODEC_FLAG2_CHUNKS
+	Flag2ShowAll           Flags2 = C.CODEC_FLAG2_SHOW_ALL
+	Flag2ExportMvs         Flags2 = C.CODEC_FLAG2_EXPORT_MVS
+	Flag2SkipManual        Flags2 = C.CODEC_FLAG2_SKIP_MANUAL
+)
+
+type Capabilities int
+
+const (
+	CapabilityDrawHorizBand     Capabilities = C.CODEC_CAP_DRAW_HORIZ_BAND
+	CapabilityDR1               Capabilities = C.CODEC_CAP_DR1
+	CapabilityTruncated         Capabilities = C.CODEC_CAP_TRUNCATED
+	CapabilityHWAccel           Capabilities = C.GO_CODEC_CAP_HWACCEL
+	CapabilityDelay             Capabilities = C.CODEC_CAP_DELAY
+	CapabilitySmallLastFrame    Capabilities = C.CODEC_CAP_SMALL_LAST_FRAME
+	CapabilityHWAccelVDPAU      Capabilities = C.GO_CODEC_CAP_HWACCEL_VDPAU
+	CapabilitySubframes         Capabilities = C.CODEC_CAP_SUBFRAMES
+	CapabilityExperimental      Capabilities = C.CODEC_CAP_EXPERIMENTAL
+	CapabilityChannelConf       Capabilities = C.CODEC_CAP_CHANNEL_CONF
+	CapabilityFrameThreads      Capabilities = C.CODEC_CAP_FRAME_THREADS
+	CapabilitySliceThreads      Capabilities = C.CODEC_CAP_SLICE_THREADS
+	CapabilityParamChange       Capabilities = C.CODEC_CAP_PARAM_CHANGE
+	CapabilityAutoThreads       Capabilities = C.CODEC_CAP_AUTO_THREADS
+	CapabilityVariableFrameSize Capabilities = C.CODEC_CAP_VARIABLE_FRAME_SIZE
+	CapabilityIntraOnly         Capabilities = C.CODEC_CAP_INTRA_ONLY
+	CapabilityLossless          Capabilities = C.CODEC_CAP_LOSSLESS
+)

--- a/avfilter/avfilter.go
+++ b/avfilter/avfilter.go
@@ -402,6 +402,16 @@ func (ctx *Context) FrameRate() *avutil.Rational {
 	return avutil.NewRationalFromC(unsafe.Pointer(&r))
 }
 
+func (ctx *Context) SendCommand(cmd, args string) error {
+	cmdString := C.CString(cmd)
+	argsString := C.CString(args)
+	code := C.avfilter_process_command(ctx.CAVFilterContext, cmdString, argsString, nil, 0, C.int(0))
+	if code < 0 {
+		return avutil.NewErrorFromCode(avutil.ErrorCode(int(code)))
+	}
+	return nil
+}
+
 type Graph struct {
 	CAVFilterGraph *C.AVFilterGraph
 }

--- a/avfilter/avfilter.go
+++ b/avfilter/avfilter.go
@@ -321,22 +321,16 @@ func (ctx *Context) WriteFrame(frame *avutil.Frame) error {
 	return nil
 }
 
-func (ctx *Context) GetFrame(frame *avutil.Frame) (bool, error) {
+func (ctx *Context) GetFrame(frame *avutil.Frame) error {
 	var cFrame *C.AVFrame
 	if frame != nil {
 		cFrame = (*C.AVFrame)(unsafe.Pointer(frame.CAVFrame))
 	}
 	code := C.av_buffersink_get_frame(ctx.CAVFilterContext, cFrame)
 	if code < 0 {
-		switch avutil.ErrorCode(code) {
-		case avutil.ErrorCode(C.GO_AVERROR(C.EAGAIN)):
-			return false, nil
-		case avutil.ErrorCodeEOF:
-			return false, nil
-		}
-		return false, avutil.NewErrorFromCode(avutil.ErrorCode(code))
+		return avutil.NewErrorFromCode(avutil.ErrorCode(code))
 	}
-	return true, nil
+	return nil
 }
 
 func (ctx *Context) SetFrameSize(size uint) {

--- a/avfilter/avfilter.go
+++ b/avfilter/avfilter.go
@@ -41,7 +41,8 @@ import (
 )
 
 var (
-	ErrAllocationError = errors.New("allocation error")
+	ErrAllocationError = errors.New("avfilter: allocation error")
+	ErrNoFilter        = errors.New("avfilter: Could not find filter")
 )
 
 type Flags int
@@ -132,14 +133,14 @@ func Filters() []*Filter {
 	return filters
 }
 
-func FindFilterByName(name string) *Filter {
+func FindFilterByName(name string) (*Filter, error) {
 	cName := C.CString(name)
 	defer C.free(unsafe.Pointer(cName))
 	cFilter := C.avfilter_get_by_name(cName)
 	if cFilter == nil {
-		return nil
+		return nil, ErrNoFilter
 	}
-	return NewFilterFromC(unsafe.Pointer(cFilter))
+	return NewFilterFromC(unsafe.Pointer(cFilter)), nil
 }
 
 type Link struct {

--- a/avfilter/avfilter.go
+++ b/avfilter/avfilter.go
@@ -30,7 +30,7 @@ package avfilter
 //#define GO_AVFILTER_AUTO_CONVERT_ALL ((unsigned)AVFILTER_AUTO_CONVERT_ALL)
 //#define GO_AVFILTER_AUTO_CONVERT_NONE ((unsigned)AVFILTER_AUTO_CONVERT_NONE)
 //
-//#cgo pkg-config: libavfilter libavutil
+// #cgo LDFLAGS: -lavfilter -lavutil
 import "C"
 
 import (

--- a/avfilter/avfilter.go
+++ b/avfilter/avfilter.go
@@ -37,7 +37,7 @@ import (
 	"errors"
 	"unsafe"
 
-	"github.com/imkira/go-libav/avutil"
+	"github.com/SpalkLtd/go-libav/avutil"
 )
 
 var (

--- a/avfilter/avfilter_test.go
+++ b/avfilter/avfilter_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/imkira/go-libav/avutil"
+	"github.com/SpalkLtd/go-libav/avutil"
 	"github.com/shirou/gopsutil/process"
 )
 

--- a/avformat/avformat.go
+++ b/avformat/avformat.go
@@ -1039,6 +1039,10 @@ func (ctx *IOContext) Error() error {
 	return nil
 }
 
+func (ctx *IOContext) Flush() {
+	C.avio_flush(ctx.CAVIOContext)
+}
+
 func boolToCInt(b bool) C.int {
 	if b {
 		return 1

--- a/avformat/avformat.go
+++ b/avformat/avformat.go
@@ -4,6 +4,7 @@ package avformat
 //#include <libavutil/avstring.h>
 //#include <libavcodec/avcodec.h>
 //#include <libavformat/avformat.h>
+//#include <stdlib.h>
 //
 //#ifdef AVFMT_FLAG_FAST_SEEK
 //#define GO_AVFMT_FLAG_FAST_SEEK AVFMT_FLAG_FAST_SEEK
@@ -45,9 +46,6 @@ package avformat
 // void set_interrupt_cb(AVFormatContext *c) {
 //	  c->interrupt_callback.callback = interrupt_cb;
 //	  c->interrupt_callback.opaque = 0;
-//}
-// void write_at(unsigned char * buf, unsigned long i, unsigned char b) {
-//	  buf[i] = b;
 //}
 //
 //
@@ -1028,13 +1026,9 @@ func (ctx *IOContext) Write(packet unsafe.Pointer, size int) {
 }
 
 func (ctx *IOContext) WriteBytes(b []byte) {
-	size := C.ulong(len(b))
-	buf := C.av_mallocz(size)
-	for i := C.ulong(0); i < size; i++ {
-		C.write_at((*C.uchar)(buf), i, C.uchar(b[i]))
-	}
+	buf := C.CBytes(b)
 	ctx.Write(buf, len(b))
-	C.av_free(buf)
+	C.free(buf)
 }
 
 func (ctx *IOContext) Error() error {

--- a/avformat/avformat.go
+++ b/avformat/avformat.go
@@ -45,8 +45,8 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/imkira/go-libav/avcodec"
-	"github.com/imkira/go-libav/avutil"
+	"github.com/SpalkLtd/go-libav/avcodec"
+	"github.com/SpalkLtd/go-libav/avutil"
 )
 
 var (

--- a/avformat/avformat.go
+++ b/avformat/avformat.go
@@ -53,7 +53,6 @@ import "C"
 
 import (
 	"errors"
-	"log"
 	"strings"
 	"time"
 	"unsafe"
@@ -899,7 +898,6 @@ func (ctx *Context) FindStreamInfo(options []*avutil.Dictionary) error {
 		cOptions = newCAVDictionaryArrayFromDictionarySlice(options[:count])
 		defer freeCAVDictionaryArray(cOptions)
 	}
-	log.Println("Attempting to find stream information")
 	code := C.avformat_find_stream_info(ctx.CAVFormatContext, cOptions)
 	if code < 0 {
 		return avutil.NewErrorFromCode(avutil.ErrorCode(code))

--- a/avformat/avformat.go
+++ b/avformat/avformat.go
@@ -40,7 +40,7 @@ package avformat
 //   return fn(s, type, data, data_size);
 // }
 // int interrupt_cb(void* data) {
-//	return (intptr_t)data;
+//	return data==NULL ? 0 : *((int*)data);
 // }
 // void set_interrupt_cb(AVFormatContext *c) {
 //	  c->interrupt_callback.callback = interrupt_cb;
@@ -959,6 +959,11 @@ func (ctx *Context) ControlMessage(msg int, data interface{}) (int64, error) {
 
 func (ctx *Context) InterruptBlockingOperation() {
 	data := C.int(1)
+	ctx.CAVFormatContext.interrupt_callback.opaque = unsafe.Pointer(&data)
+}
+
+func (ctx *Context) UninterruptBlockingOperation() {
+	data := C.int(0)
 	ctx.CAVFormatContext.interrupt_callback.opaque = unsafe.Pointer(&data)
 }
 

--- a/avformat/avformat.go
+++ b/avformat/avformat.go
@@ -940,7 +940,7 @@ func (ctx *Context) ControlMessage(msg int, data interface{}) error {
 	pointer := unsafe.Pointer(nil)
 	if data != nil {
 		//Convert data to an unsafe pointer
-		cData := C.int(data.(int64))
+		cData := C.int64_t(data.(int64))
 		pointer = unsafe.Pointer(&cData)
 	}
 

--- a/avformat/avformat.go
+++ b/avformat/avformat.go
@@ -169,6 +169,10 @@ func RegisterAll() {
 	C.av_register_all()
 }
 
+func NetworkInit() {
+	C.avformat_network_init()
+}
+
 type CodecTagList struct {
 	CAVCodecTag **C.struct_AVCodecTag
 }

--- a/avformat/avformat.go
+++ b/avformat/avformat.go
@@ -939,15 +939,16 @@ func (ctx *Context) ControlMessage(msg int, data interface{}) (int64, error) {
 	}
 	var cData C.int64_t
 	pointer := unsafe.Pointer(nil)
-	if data != nil {
-		//Convert data to an unsafe pointer
-		i64Data, ok := data.(int64)
-		if !ok {
-			return 0, errors.New("Data is not an int64")
-		}
-		cData = C.int64_t(i64Data)
-		pointer = unsafe.Pointer(&cData)
+	if data == nil {
+		data = int64(0)
 	}
+	//Convert data to an unsafe pointer
+	i64Data, ok := data.(int64)
+	if !ok {
+		return 0, errors.New("Data is not an int64")
+	}
+	cData = C.int64_t(i64Data)
+	pointer = unsafe.Pointer(&cData)
 
 	code := C.exec_cb(ctx.Output().CAVOutputFormat.control_message, ctx.CAVFormatContext, C.int(msg), pointer, 0)
 	if code < 0 {

--- a/avformat/avformat.go
+++ b/avformat/avformat.go
@@ -668,16 +668,46 @@ func (ctx *Context) WriteTrailer() error {
 	return nil
 }
 
-func (ctx *Context) ReadFrame(pkt *avcodec.Packet) (bool, error) {
+func (ctx *Context) ReadFrame() (*avcodec.Packet, error) {
+	pkt, err := avcodec.NewPacket()
+	if err != nil {
+		return nil, err
+	}
 	cPkt := (*C.AVPacket)(unsafe.Pointer(pkt.CAVPacket))
 	code := C.av_read_frame(ctx.CAVFormatContext, cPkt)
 	if code < 0 {
-		if avutil.ErrorCode(code) == avutil.ErrorCodeEOF {
-			return false, nil
-		}
-		return false, avutil.NewErrorFromCode(avutil.ErrorCode(code))
+		// if avutil.ErrorCode(code) == avutil.ErrorCodeEOF {
+		// 	return nil, nil
+		// }
+		return nil, avutil.NewErrorFromCode(avutil.ErrorCode(code))
 	}
-	return true, nil
+	return pkt, nil
+}
+
+/**
+* Start playing a network-based stream (e.g. RTSP stream) at the
+* current position.
+ */
+func (ctx *Context) ReadPlay() error {
+
+	code := C.av_read_play(ctx.CAVFormatContext)
+	if code < 0 {
+		return avutil.NewErrorFromCode(avutil.ErrorCode(code))
+	}
+	return nil
+}
+
+/**
+* Pause playing a network-based stream (e.g. RTSP stream) at the
+* current position.
+ */
+func (ctx *Context) ReadPause() error {
+
+	code := C.av_read_pause(ctx.CAVFormatContext)
+	if code < 0 {
+		return avutil.NewErrorFromCode(avutil.ErrorCode(code))
+	}
+	return nil
 }
 
 func (ctx *Context) WriteFrame(pkt *avcodec.Packet) error {

--- a/avformat/avformat.go
+++ b/avformat/avformat.go
@@ -1,6 +1,5 @@
 package avformat
 
-//#include <stdint.h>
 //#include <libavutil/avutil.h>
 //#include <libavutil/avstring.h>
 //#include <libavcodec/avcodec.h>
@@ -43,14 +42,9 @@ package avformat
 // int interrupt_cb(void* data) {
 //	return (intptr_t)data;
 // }
-// AVIOInterruptCB * alloc_interrupt_cb() {
-//	 AVIOInterruptCB * avioicb = malloc(sizeof(AVIOInterruptCB));
-//   avioicb->callback = interrupt_cb;
-//   avioicb->opaque = 0;
-//   return avioicb;
-// }
-// void set_interrupt_cb(AVFormatContext *c, AVIOInterruptCB *cb) {
-//	  c->interrupt_callback = *cb;
+// void set_interrupt_cb(AVFormatContext *c) {
+//	  c->interrupt_callback.callback = interrupt_cb;
+//	  c->interrupt_callback.opaque = 0;
 //}
 //
 //
@@ -81,15 +75,8 @@ func NewIOInterruptCallbackFromC(cb unsafe.Pointer) *IOInterruptCallback {
 	return &IOInterruptCallback{CAVIOInterruptCB: (*C.AVIOInterruptCB)(cb)}
 }
 
-func NewInterruptCallback() *IOInterruptCallback {
-	cInterrupt := C.alloc_interrupt_cb()
-	return NewIOInterruptCallbackFromC(unsafe.Pointer(cInterrupt))
-}
-
-func (ctx *Context) SetInterruptCallback(cb *IOInterruptCallback) {
-	if cb != nil {
-		C.set_interrupt_cb(ctx.CAVFormatContext, cb.CAVIOInterruptCB)
-	}
+func (ctx *Context) SetInterruptCallback() {
+	C.set_interrupt_cb(ctx.CAVFormatContext)
 }
 
 type Flags int
@@ -620,11 +607,10 @@ func NewContextForOutput(output *Output) (*Context, error) {
 }
 
 func NewContextFromC(cCtx unsafe.Pointer) *Context {
-	interrupt := NewInterruptCallback()
 	ctx := Context{
 		CAVFormatContext: (*C.AVFormatContext)(cCtx),
 	}
-	ctx.SetInterruptCallback(interrupt)
+	ctx.SetInterruptCallback()
 	return &ctx
 }
 

--- a/avformat/avformat.go
+++ b/avformat/avformat.go
@@ -933,11 +933,18 @@ func (ctx *Context) SeekToTimestamp(streamIndex int, min, target, max int64, fla
 	return nil
 }
 
-func (ctx *Context) ControlMessage(msg int) error {
+func (ctx *Context) ControlMessage(msg int, data interface{}) error {
 	if ctx.Output() == nil {
 		return errors.New("No output found")
 	}
-	code := C.exec_cb(ctx.Output().CAVOutputFormat.control_message, ctx.CAVFormatContext, C.int(msg), nil, 0)
+	pointer := unsafe.Pointer(nil)
+	if data != nil {
+		//Convert data to an unsafe pointer
+		cData := C.int(data.(int64))
+		pointer = unsafe.Pointer(&cData)
+	}
+
+	code := C.exec_cb(ctx.Output().CAVOutputFormat.control_message, ctx.CAVFormatContext, C.int(msg), pointer, 0)
 	if code < 0 {
 		return avutil.NewErrorFromCode(avutil.ErrorCode(code))
 	}

--- a/avformat/avformat.go
+++ b/avformat/avformat.go
@@ -36,7 +36,7 @@ package avformat
 //typedef int (*AVFormatContextIOOpenCallback)(struct AVFormatContext *s, AVIOContext **pb, const char *url, int flags, AVDictionary **options);
 //typedef void (*AVFormatContextIOCloseCallback)(struct AVFormatContext *s, AVIOContext *pb);
 //
-// #cgo pkg-config: libavformat libavutil
+// #cgo LDFLAGS: -lavformat -lavutil
 import "C"
 
 import (

--- a/avformat/avformat.go
+++ b/avformat/avformat.go
@@ -84,10 +84,9 @@ func (ctx *Context) SetInterruptCallback() {
 type Flags int
 
 const (
-	FlagNoFile     Flags = C.AVFMT_NOFILE
-	FlagNeedNumber Flags = C.AVFMT_NEEDNUMBER
-	FlagShowIDs    Flags = C.AVFMT_SHOW_IDS
-	// FlagRawPicture   Flags = C.AVFMT_RAWPICTURE
+	FlagNoFile       Flags = C.AVFMT_NOFILE
+	FlagNeedNumber   Flags = C.AVFMT_NEEDNUMBER
+	FlagShowIDs      Flags = C.AVFMT_SHOW_IDS
 	FlagGlobalHeader Flags = C.AVFMT_GLOBALHEADER
 	FlagNoTimestamps Flags = C.AVFMT_NOTIMESTAMPS
 	FlagGenericIndex Flags = C.AVFMT_GENERIC_INDEX

--- a/avformat/avformat.go
+++ b/avformat/avformat.go
@@ -944,7 +944,7 @@ func (ctx *Context) ControlMessage(msg int) error {
 	return nil
 }
 
-func (ctx *Context) InterruptFormatProbe() {
+func (ctx *Context) InterruptBlockingOperation() {
 	data := C.int(1)
 	ctx.CAVFormatContext.interrupt_callback.opaque = unsafe.Pointer(&data)
 }

--- a/avformat/avformat.go
+++ b/avformat/avformat.go
@@ -81,10 +81,10 @@ func (ctx *Context) SetInterruptCallback() {
 type Flags int
 
 const (
-	FlagNoFile       Flags = C.AVFMT_NOFILE
-	FlagNeedNumber   Flags = C.AVFMT_NEEDNUMBER
-	FlagShowIDs      Flags = C.AVFMT_SHOW_IDS
-	FlagRawPicture   Flags = C.AVFMT_RAWPICTURE
+	FlagNoFile     Flags = C.AVFMT_NOFILE
+	FlagNeedNumber Flags = C.AVFMT_NEEDNUMBER
+	FlagShowIDs    Flags = C.AVFMT_SHOW_IDS
+	// FlagRawPicture   Flags = C.AVFMT_RAWPICTURE
 	FlagGlobalHeader Flags = C.AVFMT_GLOBALHEADER
 	FlagNoTimestamps Flags = C.AVFMT_NOTIMESTAMPS
 	FlagGenericIndex Flags = C.AVFMT_GENERIC_INDEX

--- a/avformat/avformat30.go
+++ b/avformat/avformat30.go
@@ -7,7 +7,7 @@ package avformat
 //#include <libavcodec/avcodec.h>
 //#include <libavformat/avformat.h>
 //
-// #cgo pkg-config: libavformat libavutil
+// #cgo LDFLAGS: -lavformat -lavutil
 import "C"
 
 import (

--- a/avformat/avformat30.go
+++ b/avformat/avformat30.go
@@ -13,8 +13,8 @@ import "C"
 import (
 	"unsafe"
 
-	"github.com/imkira/go-libav/avcodec"
-	"github.com/imkira/go-libav/avutil"
+	"github.com/SpalkLtd/go-libav/avcodec"
+	"github.com/SpalkLtd/go-libav/avutil"
 )
 
 func ApplyBitstreamFilters(codecCtx *avcodec.Context, pkt *avcodec.Packet, filtersCtx *avcodec.BitStreamFilterContext) error {

--- a/avformat/avformat_test.go
+++ b/avformat/avformat_test.go
@@ -13,8 +13,8 @@ import (
 	"testing"
 	"unsafe"
 
-	"github.com/imkira/go-libav/avcodec"
-	"github.com/imkira/go-libav/avutil"
+	"github.com/SpalkLtd/go-libav/avcodec"
+	"github.com/SpalkLtd/go-libav/avutil"
 	"github.com/shirou/gopsutil/process"
 )
 

--- a/avutil/avutil.go
+++ b/avutil/avutil.go
@@ -55,7 +55,7 @@ package avutil
 //  return AVERROR(e);
 //}
 //
-// #cgo LDFLAGS: -lavutil
+// #cgo LDFLAGS: -lavutil -lm
 import "C"
 
 import (

--- a/avutil/avutil.go
+++ b/avutil/avutil.go
@@ -85,6 +85,8 @@ const (
 	LogLevelTrace   LogLevel = C.GO_AV_LOG_TRACE
 )
 
+const NoPtsValue int64 = C.AV_NOPTS_VALUE
+
 type MediaType C.enum_AVMediaType
 
 const (

--- a/avutil/avutil.go
+++ b/avutil/avutil.go
@@ -1266,15 +1266,23 @@ func (oa *OptionAccessor) SetVideoRateOptionWithFlags(name string, value *Ration
 	return nil
 }
 
-func (oa *OptionAccessor) SetChannelLayoutOption(name string, value int64) error {
-	return oa.SetChannelLayoutOptionWithFlags(name, value, OptionSearchChildren)
+func (oa *OptionAccessor) SetChannelLayoutOption(value ChannelLayout) error {
+	return oa.SetChannelLayoutOptionWithFlags(value, OptionSearchChildren)
 }
 
-func (oa *OptionAccessor) SetChannelLayoutOptionWithFlags(name string, value int64, flags OptionSearchFlags) error {
+func (oa *OptionAccessor) SetChannelLayoutOptionWithFlags(value ChannelLayout, flags OptionSearchFlags) error {
+	return oa.SetOptionWithFlags("channel_layout", value.Name(), flags)
+}
+
+func (oa *OptionAccessor) SetSampleFormatOption(name string, value SampleFormat) error {
+	return oa.SetSampleFormatOptionWithFlags(name, value, OptionSearchChildren)
+}
+
+func (oa *OptionAccessor) SetSampleFormatOptionWithFlags(name string, value SampleFormat, flags OptionSearchFlags) error {
 	cName := C.CString(name)
 	defer C.free(unsafe.Pointer(cName))
 	searchFlags := oa.searchFlags(flags)
-	code := C.av_opt_set_channel_layout(oa.obj, cName, (C.int64_t)(value), searchFlags)
+	code := C.av_opt_set_sample_fmt(oa.obj, cName, (C.enum_AVSampleFormat)(value), searchFlags)
 	if code < 0 {
 		return NewErrorFromCode(ErrorCode(code))
 	}

--- a/avutil/avutil.go
+++ b/avutil/avutil.go
@@ -975,6 +975,30 @@ func (f *Frame) PacketDuration() int64 {
 	return int64(C.av_frame_get_pkt_duration(f.CAVFrame))
 }
 
+func (f *Frame) ChannelLayout() ChannelLayout {
+	return ChannelLayout(C.av_frame_get_channel_layout(f.CAVFrame))
+}
+
+func (f *Frame) SetChannelLayout(cl ChannelLayout) {
+	C.av_frame_set_channel_layout(f.CAVFrame, C.int64_t(cl))
+}
+
+func (f *Frame) SampleFormat() SampleFormat {
+	return SampleFormat(f.CAVFrame.format)
+}
+
+func (f *Frame) SetSampleFormat(sf SampleFormat) {
+	f.CAVFrame.format = (C.int)(sf)
+}
+
+func (f *Frame) SampleRate() int {
+	return int(C.av_frame_get_sample_rate(f.CAVFrame))
+}
+
+func (f *Frame) SetSampleRate(sr int) {
+	C.av_frame_set_sample_rate(f.CAVFrame, C.int(sr))
+}
+
 type OptionAccessor struct {
 	obj  unsafe.Pointer
 	fake bool

--- a/avutil/avutil.go
+++ b/avutil/avutil.go
@@ -54,7 +54,7 @@ package avutil
 //  return AVERROR(e);
 //}
 //
-// #cgo pkg-config: libavutil
+// #cgo LDFLAGS: -lavutil
 import "C"
 
 import (

--- a/avutil/avutil.go
+++ b/avutil/avutil.go
@@ -1595,7 +1595,6 @@ func (a *AudioFifo) Peek(maxSamples int, frame *Frame) (int, error) {
 func (a *AudioFifo) PeekAt(nb_samples, offset int, frame *Frame) (int, error) {
 	cNbSamples := C.int(nb_samples)
 	cOffset := C.int(offset)
-
 	// Make sure these are set correctly here
 	frame.SetSampleFormat(a.SampleFmt)
 	frame.SetChannelLayout(a.ChannelLayout)

--- a/avutil/avutil.go
+++ b/avutil/avutil.go
@@ -997,6 +997,14 @@ func (f *Frame) SetChannelLayout(cl ChannelLayout) {
 	C.av_frame_set_channel_layout(f.CAVFrame, C.int64_t(cl))
 }
 
+func (f *Frame) Channels() int {
+	return int(C.av_frame_get_channels(f.CAVFrame))
+}
+
+func (f *Frame) SetChannels(n int) {
+	C.av_frame_set_channels(f.CAVFrame, C.int(n))
+}
+
 func (f *Frame) SampleFormat() SampleFormat {
 	return SampleFormat(f.CAVFrame.format)
 }

--- a/avutil/avutil.go
+++ b/avutil/avutil.go
@@ -196,6 +196,20 @@ func (sfmt SampleFormat) NameOk() (string, bool) {
 	return cStringToStringOk(C.av_get_sample_fmt_name((C.enum_AVSampleFormat)(sfmt)))
 }
 
+func (sfmt SampleFormat) Int() int {
+	return int(C.enum_AVSampleFormat(sfmt))
+}
+
+func (sfmt SampleFormat) BytesPerSample() int {
+	cBytes := C.av_get_bytes_per_sample(C.enum_AVSampleFormat(sfmt))
+	return int(cBytes)
+}
+
+func (sfmt SampleFormat) IsPlanar() bool {
+	cInt := C.av_sample_fmt_is_planar(C.enum_AVSampleFormat(sfmt))
+	return bool(cInt != 0)
+}
+
 type PixelFormat C.enum_AVPixelFormat
 
 const (

--- a/avutil/genhack.go
+++ b/avutil/genhack.go
@@ -148,7 +148,7 @@ package avutil
 //  return (int64_t)(AV_NOPTS_VALUE);
 //}
 //
-// #cgo pkg-config: libavutil
+// #cgo LDFLAGS: -lavutil
 import "C"
 
 const (

--- a/examples/transcoder.go
+++ b/examples/transcoder.go
@@ -6,18 +6,18 @@
 //
 // Tested with
 //
-// go run transcoder.go --input=https://bintray.com/imkira/go-libav/download_file?file_path=sample_iPod.m4v --output=output.mp4
-// go run transcoder.go --input=https://bintray.com/imkira/go-libav/download_file?file_path=sample_iPod.m4v --output=output.avi
+// go run transcoder.go --input=https://bintray.com/SpalkLtd/go-libav/download_file?file_path=sample_iPod.m4v --output=output.mp4
+// go run transcoder.go --input=https://bintray.com/SpalkLtd/go-libav/download_file?file_path=sample_iPod.m4v --output=output.avi
 package main
 
 import (
 	"flag"
 	"log"
 
-	"github.com/imkira/go-libav/avcodec"
-	"github.com/imkira/go-libav/avfilter"
-	"github.com/imkira/go-libav/avformat"
-	"github.com/imkira/go-libav/avutil"
+	"github.com/SpalkLtd/go-libav/avcodec"
+	"github.com/SpalkLtd/go-libav/avfilter"
+	"github.com/SpalkLtd/go-libav/avformat"
+	"github.com/SpalkLtd/go-libav/avutil"
 )
 
 var inputFileName, outputFileName string


### PR DESCRIPTION
- Add `avcodec.IOContext.Flush` method
- Use go builtin to get go byte array from C
- Add `avcodec.Packet.GetDataInto` to get data into an existing go byte array
- Make `avcodec.Packet.Free` a noop on a nil packet (aligns with libav convention)